### PR TITLE
Add RSSI and SNR methods, add SpiDevice support

### DIFF
--- a/rfm95/Cargo.toml
+++ b/rfm95/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-lora-rfm95"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["KizzyCode Software Labs./Keziah Biermann <development@kizzycode.de>"]
 keywords = ["no-std", "embedded", "hardware-support", "lora", "rfm95"]

--- a/rfm95/Cargo.toml
+++ b/rfm95/Cargo.toml
@@ -23,6 +23,7 @@ fugit = ["dep:fugit"]
 
 [dependencies]
 embedded-hal = { version = "1.0.0", default-features = false }
+embedded-hal-bus = { version = "0.3", default-features = false }
 fugit = { version = "0.3.7", default-features = false, optional = true }
 
 

--- a/rfm95/src/lora/types.rs
+++ b/rfm95/src/lora/types.rs
@@ -94,7 +94,7 @@ impl Bandwidth {
 /// The coding rate for forward error correction
 ///
 /// # Representation
-/// The spreading factor can be represented as `u8`, where the value is the difference to the overhead divisor (i.e.
+/// The coding rate can be represented as `u8`, where the value is the difference to the overhead divisor (i.e.
 /// `4/5 => 1`, `4/7 => 3`). The representation is compatible to the modem representation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
@@ -124,7 +124,7 @@ impl CodingRate {
 /// The IQ polarity
 ///
 /// # Representation
-/// The spreading factor can be represented as `u8`, where `Normal => 0`, `Inverted => 1`. The representation is
+/// The polarity can be represented as `u8`, where `Normal => 0`, `Inverted => 1`. The representation is
 /// compatible to the modem representation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -148,7 +148,7 @@ impl Polarity {
 /// The LoRa header mode
 ///
 /// # Representation
-/// The spreading factor can be represented as `u8`, where `Explicit => 0`, `Implicit => 1`. The representation is
+/// The header mode can be represented as `u8`, where `Explicit => 0`, `Implicit => 1`. The representation is
 /// compatible to the modem representation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -172,7 +172,7 @@ impl HeaderMode {
 /// The CRC configuration
 ///
 /// # Representation
-/// The spreading factor can be represented as `u8`, where `Disabled => 0`, `Enabled => 1`. The representation is
+/// The CRC mode can be represented as `u8`, where `Disabled => 0`, `Enabled => 1`. The representation is
 /// compatible to the modem representation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]

--- a/rfm95/src/rfm95/connection.rs
+++ b/rfm95/src/rfm95/connection.rs
@@ -4,24 +4,19 @@ use crate::err;
 use crate::error::IoError;
 use crate::rfm95::registers::Register;
 use core::fmt::{Debug, Formatter};
-use embedded_hal::digital::OutputPin;
-use embedded_hal::spi::SpiBus;
+use embedded_hal::spi::SpiDevice;
 
 /// A RFM95 SPI connection
-pub struct Rfm95Connection<Bus, Select>
+pub struct Rfm95Connection<Device>
 where
-    Bus: SpiBus,
-    Select: OutputPin,
+    Device: SpiDevice,
 {
-    /// The SPI bus
-    bus: Bus,
-    /// The chip select line
-    select: Select,
+    /// The SPI device
+    device: Device,
 }
-impl<Bus, Select> Rfm95Connection<Bus, Select>
+impl<Device> Rfm95Connection<Device>
 where
-    Bus: SpiBus,
-    Select: OutputPin,
+    Device: SpiDevice,
 {
     /// A register read operation
     const RO: u8 = 0b0000_0000;
@@ -29,8 +24,8 @@ where
     const RW: u8 = 0b1000_0000;
 
     /// Creates a new RFM95 SPI connection
-    pub const fn init(bus: Bus, select: Select) -> Self {
-        Self { bus, select }
+    pub const fn init(device: Device) -> Self {
+        Self { device }
     }
 
     /// Reads a RFM95 register via SPI
@@ -69,9 +64,9 @@ where
         let mut command = [operation | address, payload];
 
         // Do transaction
-        self.select.set_low().map_err(|_| err!(IoError, "Failed to pull chip-select line to low"))?;
-        self.bus.transfer_in_place(&mut command).map_err(|_| err!(IoError, "Failed to do SPI transaction"))?;
-        self.select.set_high().map_err(|_| err!(IoError, "Failed to pull chip-select line to high"))?;
+        self.device
+            .transfer_in_place(&mut command)
+            .map_err(|_| err!(IoError, "Failed to do GPIO operation or SPI transaction"))?;
 
         // SPI debug callback
         #[cfg(feature = "debug")]
@@ -89,12 +84,11 @@ where
         Ok(command[1])
     }
 }
-impl<Bus, Select> Debug for Rfm95Connection<Bus, Select>
+impl<Device> Debug for Rfm95Connection<Device>
 where
-    Bus: SpiBus,
-    Select: OutputPin,
+    Device: SpiDevice,
 {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        f.debug_struct("Rfm95Connection").field("bus", &"<SpiBus>").field("select", &"<OutputPin>").finish()
+        f.debug_struct("Rfm95Connection").field("device", &"<SpiDevice>").finish()
     }
 }

--- a/rfm95/src/rfm95/connection.rs
+++ b/rfm95/src/rfm95/connection.rs
@@ -64,8 +64,7 @@ where
         let mut command = [operation | address, payload];
 
         // Do transaction
-        self.device
-            .transfer_in_place(&mut command)
+        (self.device.transfer_in_place(&mut command))
             .map_err(|_| err!(IoError, "Failed to do GPIO operation or SPI transaction"))?;
 
         // SPI debug callback

--- a/rfm95/src/rfm95/driver.rs
+++ b/rfm95/src/rfm95/driver.rs
@@ -15,21 +15,46 @@ use core::fmt::{Debug, Formatter};
 use core::time::Duration;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
-use embedded_hal::spi::SpiBus;
+use embedded_hal::spi::SpiDevice;
+use embedded_hal_bus::spi::ExclusiveDevice;
 
 /// Raw SPI command interface for RFM95
-pub struct Rfm95Driver<Bus, Select>
+pub struct Rfm95Driver<Device>
 where
-    Bus: SpiBus,
-    Select: OutputPin,
+    Device: SpiDevice,
 {
     /// The SPI connection to the RFM95 radio
-    spi: Rfm95Connection<Bus, Select>,
+    spi: Rfm95Connection<Device>,
 }
-impl<Bus, Select> Rfm95Driver<Bus, Select>
+impl<Bus, Select, Delay> Rfm95Driver<ExclusiveDevice<Bus, Select, Delay>>
 where
-    Bus: SpiBus,
+    Bus: embedded_hal::spi::SpiBus,
     Select: OutputPin,
+    Delay: DelayNs,
+{
+    /// Creates a new raw SPI command interface for RFM95 from an SpiBus.
+    ///
+    /// # Blocking
+    /// This function blocks for at least `11ms` plus additional time for the modem transactions. If you have tight
+    /// scheduling requirements, you probably want to initialize this driver before entering your main event loop.
+    ///
+    /// # Important
+    /// The RFM95 modem is initialized to LoRa-mode and put to standby. All other configurations are left untouched, so
+    /// you probably want to configure the modem initially (also see [`Self::set_config`]).
+    pub fn new<Reset>(bus: Bus, select: Select, mut reset: Reset, mut timer: Delay) -> Result<Self, IoError>
+    where
+        Reset: OutputPin,
+    {
+        Self::reset_module(&mut reset, &mut timer)?;
+        let device = ExclusiveDevice::new(bus, select, timer)
+            .map_err(|_| err!(IoError, "Failed to pull chip select line to high"))?;
+
+        Self::setup(device)
+    }
+}
+impl<Device> Rfm95Driver<Device>
+where
+    Device: SpiDevice,
 {
     /// Supported silicon revisions for compatibility check
     #[cfg(not(feature = "debug"))]
@@ -56,7 +81,7 @@ where
     /// When operating in the low frequency range the RSSI register values are offset by this much.
     const LF_RSSI_OFFSET: i16 = -164;
 
-    /// Creates a new raw SPI command interface for RFM95
+    /// Creates a new raw SPI command interface for RFM95 from an SpiDevice.
     ///
     /// # Blocking
     /// This function blocks for at least `11ms` plus additional time for the modem transactions. If you have tight
@@ -65,10 +90,20 @@ where
     /// # Important
     /// The RFM95 modem is initialized to LoRa-mode and put to standby. All other configurations are left untouched, so
     /// you probably want to configure the modem initially (also see [`Self::set_config`]).
-    pub fn new<R, T>(bus: Bus, select: Select, mut reset: R, mut timer: T) -> Result<Self, IoError>
+    pub fn new_from_device<Reset, Timer>(device: Device, mut reset: Reset, mut timer: Timer) -> Result<Self, IoError>
     where
-        R: OutputPin,
-        T: DelayNs,
+        Reset: OutputPin,
+        Timer: DelayNs,
+    {
+        Self::reset_module(&mut reset, &mut timer)?;
+        Self::setup(device)
+    }
+
+    /// Resets the module
+    fn reset_module<Reset, Timer>(reset: &mut Reset, timer: &mut Timer) -> Result<(), IoError>
+    where
+        Reset: OutputPin,
+        Timer: DelayNs,
     {
         // Pull reset to low and wait until the reset is triggered
         reset.set_low().map_err(|_| err!(IoError, "Failed to pull reset line to low"))?;
@@ -77,9 +112,13 @@ where
         // Pull reset to high again and give the chip some time to boot
         reset.set_high().map_err(|_| err!(IoError, "Failed to pull reset line to high"))?;
         timer.delay_ms(10);
+        Ok(())
+    }
 
+    /// Does the setup common to both ::new() and ::new_from_device() fns
+    fn setup(device: Device) -> Result<Self, IoError> {
         // Validate chip revision to assure the protocol matches
-        let mut wire = Rfm95Connection::init(bus, select);
+        let mut wire = Rfm95Connection::init(device);
         #[cfg(not(feature = "debug"))]
         {
             // Get chip revision
@@ -515,12 +554,11 @@ where
         Ok(dump)
     }
 }
-impl<Bus, Select> Debug for Rfm95Driver<Bus, Select>
+impl<Device> Debug for Rfm95Driver<Device>
 where
-    Bus: SpiBus,
-    Select: OutputPin,
+    Device: SpiDevice,
 {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        f.debug_struct("Rfm95Driver").field("spi", &self.spi).finish()
+        f.debug_struct("Rfm95Driver").field("device", &self.spi).finish()
     }
 }

--- a/rfm95/src/rfm95/driver.rs
+++ b/rfm95/src/rfm95/driver.rs
@@ -93,7 +93,7 @@ where
         timer.delay_ms(10);
         Ok(())
     }
-    /// Does the setup common to both ::new() and ::new_from_device() fns
+    /// Setups the module for LoRa by setting the minimum amount of required settings
     fn setup_module(spi: &mut Rfm95Connection<Device>) -> Result<(), IoError> {
         // Validate chip revision to assure the protocol matches
         #[cfg(not(feature = "debug"))]

--- a/rfm95/src/rfm95/registers.rs
+++ b/rfm95/src/rfm95/registers.rs
@@ -16,7 +16,7 @@ pub trait Register {
 /// Declares a register type
 macro_rules! register {
     ($doc:expr, $type:ident < $address:literal, $offset:literal, $length:literal >) => {
-        /// A specific register description
+        // A specific register description
         #[derive(Debug, Clone, Copy)]
         #[doc = $doc]
         pub struct $type;

--- a/rfm95/src/rfm95/registers.rs
+++ b/rfm95/src/rfm95/registers.rs
@@ -131,6 +131,14 @@ register! {
     RegRxNbBytes<0x13, 0, 8>
 }
 register! {
+    "SNR of last packet recieved",
+    RegPktSnrValue<0x19, 0, 8>
+}
+register! {
+    "RSSI of last packet recieved",
+    RegPktRssiValue<0x1A, 0, 8>
+}
+register! {
     "Signal bandwidth (see datasheet for more info)",
     RegModemConfig1Bw<0x1D, 4, 4>
 }


### PR DESCRIPTION
Hi,

This PR adds methods to get the packet signal to noise ratio, the packet RSSI, and the packet strength as seen in section 5.5.5 of the HopeRF RFM95W/96W/98W datasheet (v2).

It also adds support for sharing an SpiBus rather than taking exclusive ownership by using SpiDevice internally. Embedded-hal [recommends drivers use SpiDevice over SpiBus](https://docs.rs/embedded-hal/latest/embedded_hal/spi/index.html#for-driver-authors) to support SPI buses with more than one peripheral. 
The internals have been modified to use SpiDevice instead of SpiBus, but to maximise backwards compatibility the `::new()` constructor still takes an SpiBus. To internally produce an SpiDevice from an SpiBus, we use `ExclusiveDevice` [from embedded-hal-bus](https://docs.rs/embedded-hal-bus/latest/embedded_hal_bus/spi/struct.ExclusiveDevice.html), which trivially wraps the bus and automates chip select (de)assertion. The only change visible to existing users is the change of generics on `Rfm95Driver`.
A new constructor `::new_from_device()` allows a user to pass in their own preconfigured SpiDevice if they need to share their SPI bus. Setup common to both constructors have been moved into `::reset_module()` and `::setup()`.

I've tested the signal strength and SpiDevice changes on an embedded platform, but haven't played around with crate feature flags. Please let me know if there's anything I've overlooked.

Comments and modifications welcome!